### PR TITLE
Improve hint timing and shuffle available actions

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -273,7 +273,9 @@
 
 .blocks-container {
     display: flex;
+    flex-wrap: wrap;
     gap: 15px;
-    overflow-x: auto;
+    overflow-y: auto;
     padding-bottom: 10px;
+    align-content: flex-start;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -82,6 +82,15 @@ body {
     color: var(--text-primary);
 }
 
+.logo.clickable {
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.logo.clickable:hover {
+    opacity: 0.7;
+}
+
 /* Game Board */
 .game-board {
     flex: 1;

--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
         <section id="game-screen" class="screen hidden">
             <header class="header">
                 <div class="header-left">
-                    <button id="btn-back-map" class="btn-icon" title="マップに戻る">←</button>
-                    <div class="logo">
+                    <button id="btn-home" class="btn-icon" title="ホームに戻る">🏠</button>
+                    <div class="logo clickable" id="logo-home">
                         <h1>Actions Factory</h1>
                     </div>
                 </div>
@@ -73,7 +73,7 @@
                 </div>
                 <div class="header-controls">
                     <button id="btn-glossary" class="btn-icon" title="用語集">📚</button>
-                    <button id="btn-settings" class="btn-icon" title="設定">⚙️</button>
+                    <button id="btn-back-map" class="btn-icon" title="レベル選択">⚙️</button>
                 </div>
             </header>
 

--- a/js/game.js
+++ b/js/game.js
@@ -130,6 +130,11 @@ const Game = {
         UI.updateStatus('FAILED');
         UI.log(reason, 'error');
         UI.log('Build Failed.', 'error');
+
+        // Show hint based on attempts after a failure
+        if (this.currentLevel) {
+            UI.logHint(this.currentLevel);
+        }
     },
 
     validateSolution: function (config) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -74,6 +74,22 @@ const UI = {
         this.elements.btnMapGlossary.addEventListener('click', () => {
             this.elements.glossaryModal.classList.remove('hidden');
         });
+
+        // ホームボタン（新規追加）
+        const btnHome = document.getElementById('btn-home');
+        if (btnHome) {
+            btnHome.addEventListener('click', () => {
+                this.showScreen('top-screen');
+            });
+        }
+
+        // ロゴクリックでTOP画面に遷移（新規追加）
+        const logoHome = document.getElementById('logo-home');
+        if (logoHome) {
+            logoHome.addEventListener('click', () => {
+                this.showScreen('top-screen');
+            });
+        }
     },
 
     showScreen: function (screenId) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -228,9 +228,10 @@ const UI = {
             this.elements.slotsContainer.appendChild(slot);
         }
 
-        // Render Palette
+        // Render Palette (randomize order each time)
         this.elements.blocksPalette.innerHTML = '';
-        level.availableBlocks.forEach(blockId => {
+        const paletteBlocks = this.shuffleArray(level.availableBlocks);
+        paletteBlocks.forEach(blockId => {
             const blockData = BLOCKS[blockId];
             if (blockData) {
                 const block = this.createBlockElement(blockData);
@@ -323,6 +324,18 @@ const UI = {
     getPipelineConfig: function () {
         const slots = Array.from(this.elements.slotsContainer.children);
         return slots.map(slot => slot.dataset.blockId).filter(id => id !== undefined && id !== '');
+    },
+
+    /**
+     * Return a shuffled copy of an array (Fisher-Yates)
+     */
+    shuffleArray: function (arr) {
+        const copy = [...arr];
+        for (let i = copy.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [copy[i], copy[j]] = [copy[j], copy[i]];
+        }
+        return copy;
     },
 
     /**

--- a/js/ui.js
+++ b/js/ui.js
@@ -225,9 +225,7 @@ const UI = {
         this.clearConsole();
         this.log(`Loaded Level ${level.id}: ${level.title}`, 'info');
         this.log(level.description, 'info');
-        if (level.hint) {
-            this.log(`HINT: ${level.hint}`, 'warning');
-        }
+        this.logHint(level);
 
         this.updateStatus('READY');
     },
@@ -322,6 +320,27 @@ const UI = {
         line.textContent = `> ${message}`;
         this.elements.consoleContent.appendChild(line);
         this.elements.consoleContent.scrollTop = this.elements.consoleContent.scrollHeight;
+    },
+
+    /**
+     * Log hint based on attempt count
+     * 0回目: ヒントなし
+     * 1回目: ソフトヒント（汎用）
+     * 2回目以降: レベル固有ヒント
+     */
+    logHint: function (level) {
+        const stats = Storage.load().stats || {};
+        const attempts = stats[level.id]?.attempts || 0;
+
+        if (attempts === 0) return; // 初回はヒントなし
+        if (attempts === 1) {
+            this.log('HINT (soft): 順序と依存関係に気をつけて組み立ててみましょう。', 'warning');
+            return;
+        }
+
+        if (level.hint) {
+            this.log(`HINT: ${level.hint}`, 'warning');
+        }
     },
 
     clearConsole: function () {

--- a/js/ui.js
+++ b/js/ui.js
@@ -348,8 +348,8 @@ const UI = {
         const stats = Storage.load().stats || {};
         const attempts = stats[level.id]?.attempts || 0;
 
-        if (attempts === 0) return; // 初回はヒントなし
-        if (attempts === 1) {
+        if (attempts <= 1) return; // 初回（attempts=1）まではヒントなし
+        if (attempts === 2) {
             this.log('HINT (soft): 順序と依存関係に気をつけて組み立ててみましょう。', 'warning');
             return;
         }


### PR DESCRIPTION
## Summary
- Show hints based on attempts: 1st none, 2nd soft hint, 3rd+ full level hint (after failures and on load)
- Show hint after a failed run to give guidance without reloading
- Shuffle Available Actions palette each render so order isn’t always the solution

## Testing
- Manual: loaded multiple levels, confirmed palette order changes, confirmed hints appear on 2nd/3rd failures as expected
